### PR TITLE
Added encoding option as a command-line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Brought to you by : <a href="https://ohuru.tech/">Ohuru</a>
 
     optional arguments:
       -h, --help           show this help message and exit
-      -d [BASE_DIRECTORY]  Provide base directory
       -a [APP_NAME]        provide django app name
+      -d [BASE_DIRECTORY]  provide base directory
+      -e [ENCODING]        provide encoding
     
 ## Description
 Converts all the HTML files specified in the files (' f ') argument into Django templates, replacing the contents of 'src', 'href' and 'url' tags with their Django compatible static conterparts with their Django App name prefixed.

--- a/djangify/djangify.py
+++ b/djangify/djangify.py
@@ -171,7 +171,7 @@ def main():
 
     logging.info("Directory : " + str(directory))
     logging.info("app_name  : " + str(APP_NAME))
-    logging.info("Encoding  : " + str(encoding))
+    logging.debug("Encoding  : " + str(encoding))
 
     # Check if the directory passed in as argument already has the directory
     # 'Modified_files', else create it.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Hi.

i'm a software developer from Turkey and we use genarelly utf-8 encoding for Turkish specific latin characters. I needed the project but i seen an error message in command-line when i try to use. After i see an [open issue](https://github.com/L4TTiCe/djangify/issues/21) (Closes #21) i wanted to contribute by generalizing the solution I used.

This is to be my first contribution, so if i maked a mistake please warn to me.

- Tested on Win10 (Python 3.10)
- imported `locale & encodings` (built-in modules)
- Comment lines added

- Sayonara